### PR TITLE
Change include conditionals (support jinja2_native=True)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
       paths:
         - "vars"
     var_files: "{{ lookup('first_found', params, errors='ignore') }}"
-  when: var_files | length > 0
+  when: var_files
 
 - include_tasks: overwrites.yml
 
@@ -23,6 +23,6 @@
       paths:
         - "tasks"
     task_files: "{{ lookup('first_found', params, errors='ignore') }}"
-  when: task_files | length
+  when: task_files
 - include_tasks: configure-apcu.yml
 - include_tasks: configure-opcache.yml


### PR DESCRIPTION
When using the jinja2_native option the files lookups will correctly return `null` when no match is found. This lead to the playbook crashing for such cases. This commit changes the conditions to simply check the truthyness of the result.
Which could be a greater than 0 length string when a match was found, or either an empty string (jinja2_native=false) or `null` (jinja2_native=true) when no match was found.

See https://github.com/owncloud-ansible/owncloud/pull/36 for more details.