### PR TITLE
feat: enable php7.4 appstream on RH 8 by default

### DIFF
--- a/molecule/rocky8/converge.yml
+++ b/molecule/rocky8/converge.yml
@@ -5,7 +5,7 @@
     php_packages_extra:
       - gcc
       - make
-    php_webserver_enabled: True
+    php_webserver_enabled: False
 
   roles:
     - role: php

--- a/molecule/rocky8/tests/test_default.py
+++ b/molecule/rocky8/tests/test_default.py
@@ -11,7 +11,7 @@ def test_php_cli(host):
     version = host.run("/usr/bin/php --version")
 
     assert version.succeeded
-    assert "7.2" in version.stdout
+    assert "7.4" in version.stdout
 
 
 def test_php_cli_config(host):

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -1,6 +1,6 @@
 ---
 __php_packages:
-  - "php"
+  - "@php:{{ php_default_version }}/minimal"
   - "php-cli"
   - "php-common"
   - "php-devel"


### PR DESCRIPTION
This PR  enables the PHP 7.4 appstream (instead of the default 7.2) on RH 8 by default and installs PHP dependencies from the stream as well:

```
[root@rocky-8-php ~]# rpm -qa | grep php
php-gd-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-ldap-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-mysqlnd-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-process-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-devel-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-json-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-pdo-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-opcache-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-xml-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-pecl-apcu-5.1.18-1.module+el8.4.0+415+e936cba3.x86_64
php-pecl-zip-1.18.2-1.module+el8.4.0+415+e936cba3.x86_64
php-common-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-intl-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-mbstring-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-pear-1.10.12-1.module+el8.4.0+415+e936cba3.noarch
php-xmlrpc-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
php-cli-7.4.19-1.module+el8.5.0+696+61e7c9ba.x86_64
```

BREAKING CHANGE: For RedHat 8 based distributions, PHP 7.4 is used by default now. 