### PR TITLE
fix: use product filter instead of zip to enable pecl modules

### DIFF
--- a/tasks/pecl.yml
+++ b/tasks/pecl.yml
@@ -14,7 +14,7 @@
     group: root
     force: yes
     mode: 0644
-  loop: "{{ php_extension_conf_paths | zip(php_pecl_modules_enabled) | list }}"
+  loop: "{{ php_extension_conf_paths | product(php_pecl_modules_enabled) | list }}"
   loop_control:
     label: "{{ item.0 }}/{{ item.1 }}.ini"
   notify:


### PR DESCRIPTION
zip in Ansible limit the lists, see https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#combining-items-from-multiple-lists-zip-and-zip-longest . What's needed here is product, see https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#products. I tested a successful deployment with this change.